### PR TITLE
generateUniqueKey: Reduce generated UUID size to 16 bytes.

### DIFF
--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -38,15 +38,8 @@ module.exports = ({ request }) ->
 	# console.log(randomKey)
 	###
 	generateUniqueKey: ->
-		# It'd be nice if the random key matched the output of a SHA-256 function,
-		# but for the purposes of a uuid we are limited by the fact that
-		# although the length limit of the CN attribute in a X.509
-		# certificate is 64 chars, a 32 byte UUID (64 chars in hex) doesn't
-		# pass the certificate validation in OpenVPN This either means that
-		# the RFC counts a final NULL byte as part of the CN or that the
-		# OpenVPN/OpenSSL implementation has a bug.
 		return randomstring.generate(
-			length: 62
+			length: 32
 			charset: 'hex'
 		)
 

--- a/tests/register.spec.coffee
+++ b/tests/register.spec.coffee
@@ -15,9 +15,9 @@ describe 'Device Register:', ->
 
 	describe '.generateUniqueKey()', ->
 
-		it 'should return a string that has a length of 62 (31 bytes)', ->
+		it 'should return a string that has a length of 32 (16 bytes)', ->
 			uniqueKey = register.generateUniqueKey()
-			expect(uniqueKey).to.be.a('string').that.has.lengthOf(62)
+			expect(uniqueKey).to.be.a('string').that.has.lengthOf(32)
 
 		it 'should generate different unique key each time', ->
 			uniqueKeys = _.times(3, register.generateUUID)


### PR DESCRIPTION
Modify the generated UUID length from 62 to 32 characters to match [4e5379](https://github.com/balena-os/meta-balena/commit/4e537949ce9131f2e47d8e24ac5e366e31e38dd6).

Change-type: patch
Signed-off-by: James Harton <james@balena.io>