### PR TITLE
Extend API exception to include full response object

### DIFF
--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -16,6 +16,7 @@ limitations under the License.
 
 Promise = require('bluebird')
 randomstring = require('randomstring')
+{ TypedError } = require 'typed-error'
 
 ###*
 # @summary Creates a Balena Register Device instance
@@ -96,7 +97,11 @@ module.exports = ({ request }) ->
 				api_key: options.deviceApiKey
 		.tap (response) ->
 			if response.statusCode isnt 201
-				throw new Error(response.body)
+				throw new ApiError(response.body, response)
 		.get('body')
 		# Allow promise based and callback based styles
 		.asCallback(callback)
+
+class ApiError extends TypedError
+	constructor: (message = 'Error with API request', @response) ->
+		super(@message)


### PR DESCRIPTION
This PR is to help unmask other information from the API request such as the statusCode. It was purposely refactored to maintain previous behavior while adding information. 

Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>