### PR TITLE
Update mocha to fix node v12 deprecation warning

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -18,6 +18,7 @@ gulp.task 'test', ->
 	gulp.src(OPTIONS.files.tests, read: false)
 		.pipe(mocha({
 			reporter: 'landing'
+			require: ['coffeescript/register']
 		}))
 
 gulp.task 'build', gulp.series [

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "coffeescript": "~1.12.2",
     "gulp": "^4.0.2",
     "gulp-coffee": "^2.3.0",
-    "gulp-mocha": "^3.0.0",
+    "gulp-mocha": "^7.0.2",
     "gulp-util": "^3.0.1",
     "karma": "^1.7.0",
     "lodash": "^4.0.0",
-    "mocha": "^3.5.0",
+    "mocha": "^6.2.0",
     "mockttp": "^0.8.0",
     "sinon": "^1.17.6"
   },


### PR DESCRIPTION
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/KkFyAM4y7FbvbEOMtnoHdkCcz7p
Change-type: patch