### PR TITLE
Switch from randomstring to uuid for generating device uuids

### DIFF
--- a/lib/register.ts
+++ b/lib/register.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as randomstring from 'randomstring';
+import { v4 as uuidv4 } from 'uuid';
 import { TypedError } from 'typed-error';
 
 interface SendResponse {
@@ -61,10 +61,7 @@ export const getRegisterDevice = ({
 	 * console.log(randomKey)
 	 */
 	generateUniqueKey() {
-		return randomstring.generate({
-			length: 32,
-			charset: 'hex',
-		});
+		return uuidv4().replace(/\-/g, '');
 	},
 
 	/**

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "sinon": "^1.17.6"
   },
   "dependencies": {
-    "@types/randomstring": "^1.1.6",
-    "randomstring": "^1.1.5",
+    "@types/uuid": "^8.0.0",
     "tslib": "^2.0.0",
-    "typed-error": "^3.2.0"
+    "typed-error": "^3.2.0",
+    "uuid": "^8.2.0"
   },
   "peerDependencies": {
     "balena-request": "^11.0.0"


### PR DESCRIPTION
For browser usage this can reduce the bundle size significantly (~330KB for balena-sdk) because it handles browser crypto via native browser crypto apis rather than relying on shimming the entirety of the nodejs crypto api